### PR TITLE
新增支持跨库子查询方法

### DIFF
--- a/Src/Asp.Net/SqlSugar/ExpressionsToSql/DbMethods/SqlFunc.cs
+++ b/Src/Asp.Net/SqlSugar/ExpressionsToSql/DbMethods/SqlFunc.cs
@@ -280,7 +280,9 @@ namespace SqlSugar
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static Subqueryable<T> Subqueryable<T>() where T:class,new(){ throw new NotSupportedException("Can only be used in expressions");}
+        public static Subqueryable<T> Subqueryable<T>() where T : class, new() { throw new NotSupportedException("Can only be used in expressions"); }
+        public static Subqueryable<T> Subqueryable<T>(bool IsCrossQueryWithAttr = false) where T : class, new() { throw new NotSupportedException("Can only be used in expressions"); }
+        public static Subqueryable<T> SubqueryableWithAttr<T>() where T : class, new() { throw new NotSupportedException("Can only be used in expressions"); }
         public static CaseThen  IF(bool condition) { throw new NotSupportedException("Can only be used in expressions"); }
         public static int CharIndex(string findChar,string searchValue) { throw new NotSupportedException("Can only be used in expressions"); }
         public static int BitwiseAnd(int left, int right) { throw new NotSupportedException("Can only be used in expressions"); }

--- a/Src/Asp.Net/SqlSugar/ExpressionsToSql/Subquery/Items/SubFromTableWithAttr.cs
+++ b/Src/Asp.Net/SqlSugar/ExpressionsToSql/Subquery/Items/SubFromTableWithAttr.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace SqlSugar
 {
-    public class SubFromTable : ISubOperation
+    public class SubFromTableWithAttr : ISubOperation
     {
         public bool HasWhere
         {
@@ -18,7 +18,7 @@ namespace SqlSugar
         {
             get
             {
-                return "Subqueryable";
+                return "SubqueryableWithAttr";
             }
         }
 
@@ -53,16 +53,10 @@ namespace SqlSugar
                 this.Context.RefreshMapping();
             }
             var result = "FROM ";
-            if (exp.Arguments.Any())
+            var tenant = entityType.GetCustomAttribute<TenantAttribute>();
+            if (tenant != null)
             {
-                if (exp.Arguments[0].ToString() == "True")
-                {
-                    var tenant = entityType.GetCustomAttribute<TenantAttribute>();
-                    if (tenant != null)
-                    {
-                        result += $"{this.Context.SqlTranslationLeft}{tenant.configId}{this.Context.SqlTranslationRight}{UtilConstants.Dot}dbo{UtilConstants.Dot}";
-                    }
-                }
+                result += $"{this.Context.SqlTranslationLeft}{tenant.configId}{this.Context.SqlTranslationRight}{UtilConstants.Dot}dbo{UtilConstants.Dot}";
             }
             result += this.Context.GetTranslationTableName(name, true);
             if (this.Context.SubQueryIndex > 0)

--- a/Src/Asp.Net/SqlSugar/ExpressionsToSql/Subquery/SubTools.cs
+++ b/Src/Asp.Net/SqlSugar/ExpressionsToSql/Subquery/SubTools.cs
@@ -24,6 +24,7 @@ namespace SqlSugar
                                                     new SubNotAny(){ Context=Context },
                                                     new SubBegin(){ Context=Context },
                                                     new SubFromTable(){ Context=Context },
+                                                    new SubFromTableWithAttr(){ Context=Context },
                                                     new SubCount(){ Context=Context },
                                                     new SubMax(){ Context=Context },
                                                     new SubMin(){ Context=Context },
@@ -48,7 +49,7 @@ namespace SqlSugar
             if (context.SubQueryIndex == 0)
                 return string.Empty;
             else
-                return "subTableIndex"+context.SubQueryIndex+".";
+                return "subTableIndex" + context.SubQueryIndex + ".";
         }
 
         public static List<ISubOperation> SubItemsConst = SubItems(null);
@@ -78,7 +79,7 @@ namespace SqlSugar
             newContext.RefreshMapping = context.RefreshMapping;
             newContext.IgnoreComumnList = context.IgnoreComumnList;
             newContext.SqlFuncServices = context.SqlFuncServices;
-            if (type == ResolveExpressType.WhereMultiple||type==ResolveExpressType.FieldMultiple) 
+            if (type == ResolveExpressType.WhereMultiple || type == ResolveExpressType.FieldMultiple)
             {
                 newContext.IsSingle = false;
             }

--- a/Src/Asp.Net/SqlSugar/SqlSugar.csproj
+++ b/Src/Asp.Net/SqlSugar/SqlSugar.csproj
@@ -172,6 +172,7 @@
     <Compile Include="ExpressionsToSql\ResolveItems\MethodCallExpressionResolve_BaseDateFomat.cs" />
     <Compile Include="ExpressionsToSql\Subquery\Items\SubDistinctCount.cs" />
     <Compile Include="ExpressionsToSql\Subquery\Items\SubFirst.cs" />
+    <Compile Include="ExpressionsToSql\Subquery\Items\SubFromTableWithAttr.cs" />
     <Compile Include="ExpressionsToSql\Subquery\Items\SubSelectStringJoin.cs" />
     <Compile Include="ExpressionsToSql\Subquery\Items\SubToList.cs" />
     <Compile Include="ExpressionsToSql\Subquery\Items\SubWithNoLock.cs" />

--- a/Src/Asp.NetCore2/SqlSugar/ExpressionsToSql/DbMethods/SqlFunc.cs
+++ b/Src/Asp.NetCore2/SqlSugar/ExpressionsToSql/DbMethods/SqlFunc.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SqlSugar
 {
@@ -21,11 +19,11 @@ namespace SqlSugar
         {
             throw new NotSupportedException("Can only be used in expressions");
         }
-        public static int CompareTo(string strA, string strB) 
+        public static int CompareTo(string strA, string strB)
         {
             throw new NotSupportedException("Can only be used in expressions");
         }
-        public static int RowNumber(object orderByField, object partitionBy) 
+        public static int RowNumber(object orderByField, object partitionBy)
         {
             throw new NotSupportedException("Can only be used in expressions");
         }
@@ -53,12 +51,12 @@ namespace SqlSugar
         {
             throw new NotSupportedException("Can only be used in expressions");
         }
-        public static string JsonField(object json,string fieldName)
+        public static string JsonField(object json, string fieldName)
         {
             throw new NotSupportedException("Can only be used in expressions");
         }
 
-        public static string JsonField(object json, string fieldName,string includeFieldName)
+        public static string JsonField(object json, string fieldName, string includeFieldName)
         {
             throw new NotSupportedException("Can only be used in expressions");
         }
@@ -90,7 +88,7 @@ namespace SqlSugar
             throw new NotSupportedException("Can only be used in expressions");
         }
 
-        public static bool JsonLike(object json,string likeStr)
+        public static bool JsonLike(object json, string likeStr)
         {
             throw new NotSupportedException("Can only be used in expressions");
         }
@@ -103,11 +101,11 @@ namespace SqlSugar
         {
             throw new NotSupportedException("Can only be used in expressions");
         }
-        public static int DateDiff(DateType dateType,DateTime littleTime, DateTime bigTime) 
+        public static int DateDiff(DateType dateType, DateTime littleTime, DateTime bigTime)
         {
             throw new NotSupportedException("Can only be used in expressions");
         }
-        public static bool GreaterThan(object thisValue,object gtValue)
+        public static bool GreaterThan(object thisValue, object gtValue)
         {
             throw new NotSupportedException("Can only be used in expressions");
         }
@@ -185,12 +183,12 @@ namespace SqlSugar
         {
             return thisValue.Equals(parameterValue);
         }
-        public  static bool EqualsNull(object thisValue, object parameterValue)
+        public static bool EqualsNull(object thisValue, object parameterValue)
         {
             return thisValue.Equals(parameterValue);
         }
 
-        public static bool Exists(string subQueryableName_Or_OneToOnePropertyName)  
+        public static bool Exists(string subQueryableName_Or_OneToOnePropertyName)
         {
             throw new NotSupportedException("Can only be used in expressions");
         }
@@ -221,12 +219,12 @@ namespace SqlSugar
         public static bool Between(object value, object start, object end) { throw new NotSupportedException("Can only be used in expressions"); }
         public static TResult IIF<TResult>(bool isTrue, TResult thenValue, TResult elseValue) { return isTrue ? thenValue : elseValue; }
         public static TResult IsNull<TResult>(TResult thisValue, TResult ifNullValue) { throw new NotSupportedException("Can only be used in expressions"); }
-        public static string MergeString(string value1,string value2) { throw new NotSupportedException("Can only be used in expressions"); }
-        public static string MergeString(string value1, string value2,string value3) { throw new NotSupportedException("Can only be used in expressions"); }
-        public static string MergeString(string value1, string value2,string value3,string value4) { throw new NotSupportedException("Can only be used in expressions"); }
-        public static string MergeString(string value1, string value2, string value3, string value4,string value5) { throw new NotSupportedException("Can only be used in expressions"); }
-        public static string MergeString(string value1, string value2, string value3, string value4, string value5,string value6) { throw new NotSupportedException("Can only be used in expressions"); }
-        public static string MergeString(string value1, string value2, string value3, string value4, string value5, string value6,string value7) { throw new NotSupportedException("Can only be used in expressions"); }
+        public static string MergeString(string value1, string value2) { throw new NotSupportedException("Can only be used in expressions"); }
+        public static string MergeString(string value1, string value2, string value3) { throw new NotSupportedException("Can only be used in expressions"); }
+        public static string MergeString(string value1, string value2, string value3, string value4) { throw new NotSupportedException("Can only be used in expressions"); }
+        public static string MergeString(string value1, string value2, string value3, string value4, string value5) { throw new NotSupportedException("Can only be used in expressions"); }
+        public static string MergeString(string value1, string value2, string value3, string value4, string value5, string value6) { throw new NotSupportedException("Can only be used in expressions"); }
+        public static string MergeString(string value1, string value2, string value3, string value4, string value5, string value6, string value7) { throw new NotSupportedException("Can only be used in expressions"); }
         public static int ToInt32(object value) { return value.ObjToInt(); }
         public static long ToInt64(object value) { return Convert.ToInt64(value); }
         /// <summary>
@@ -259,7 +257,7 @@ namespace SqlSugar
         public static TResult AggregateMax<TResult>(TResult thisValue) { throw new NotSupportedException("Can only be used in expressions"); }
         public static int AggregateCount<TResult>(TResult thisValue) { throw new NotSupportedException("Can only be used in expressions"); }
         public static int AggregateDistinctCount<TResult>(TResult thisValue) { throw new NotSupportedException("Can only be used in expressions"); }
-        public static TResult MappingColumn<TResult>(TResult type,string newColumnName) { throw new NotSupportedException("Can only be used in expressions"); }
+        public static TResult MappingColumn<TResult>(TResult type, string newColumnName) { throw new NotSupportedException("Can only be used in expressions"); }
         public static TResult MappingColumn<TResult>(string newColumnName) { throw new NotSupportedException("Can only be used in expressions"); }
         /// <summary>
         ///Example: new NewT(){name=SqlFunc.GetSelfAndAutoFill(it)}  Generated SQL   it.*
@@ -272,29 +270,31 @@ namespace SqlSugar
         public static string GetRandom() { throw new NotSupportedException("Can only be used in expressions"); }
 
 
-        public static T Abs<T>( T value) { throw new NotSupportedException("Can only be used in expressions"); }
-        public static T Round<T>(T value,int precision) { throw new NotSupportedException("Can only be used in expressions"); }
+        public static T Abs<T>(T value) { throw new NotSupportedException("Can only be used in expressions"); }
+        public static T Round<T>(T value, int precision) { throw new NotSupportedException("Can only be used in expressions"); }
 
         /// <summary>
         /// Subquery
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static Subqueryable<T> Subqueryable<T>() where T:class,new(){ throw new NotSupportedException("Can only be used in expressions");}
-        public static CaseThen  IF(bool condition) { throw new NotSupportedException("Can only be used in expressions"); }
-        public static int CharIndex(string findChar,string searchValue) { throw new NotSupportedException("Can only be used in expressions"); }
+        public static Subqueryable<T> Subqueryable<T>() where T : class, new() { throw new NotSupportedException("Can only be used in expressions"); }
+        public static Subqueryable<T> Subqueryable<T>(bool IsCrossQueryWithAttr = false) where T : class, new() { throw new NotSupportedException("Can only be used in expressions"); }
+        public static Subqueryable<T> SubqueryableWithAttr<T>() where T : class, new() { throw new NotSupportedException("Can only be used in expressions"); }
+        public static CaseThen IF(bool condition) { throw new NotSupportedException("Can only be used in expressions"); }
+        public static int CharIndex(string findChar, string searchValue) { throw new NotSupportedException("Can only be used in expressions"); }
         public static int BitwiseAnd(int left, int right) { throw new NotSupportedException("Can only be used in expressions"); }
         public static int BitwiseInclusiveOR(int left, int right) { throw new NotSupportedException("Can only be used in expressions"); }
-        public static DateTime Oracle_ToDate(string date,string format) { throw new NotSupportedException("Can only be used in expressions"); }
+        public static DateTime Oracle_ToDate(string date, string format) { throw new NotSupportedException("Can only be used in expressions"); }
         public static string Oracle_ToChar(DateTime date, string format) { throw new NotSupportedException("Can only be used in expressions"); }
-        public static int SqlServer_DateDiff(string dateType,DateTime date1,DateTime date2) { throw new NotSupportedException("Can only be used in expressions"); }
+        public static int SqlServer_DateDiff(string dateType, DateTime date1, DateTime date2) { throw new NotSupportedException("Can only be used in expressions"); }
 
         public static bool JsonListObjectAny(object jsonListObject, string fieldName, object value)
         {
             throw new NotSupportedException("Can only be used in expressions");
         }
 
-        public static bool JsonArrayAny(object jsonArray,object arrayValue) 
+        public static bool JsonArrayAny(object jsonArray, object arrayValue)
         {
             throw new NotSupportedException("Can only be used in expressions");
         }
@@ -304,7 +304,7 @@ namespace SqlSugar
             throw new NotSupportedException("Can only be used in expressions");
         }
 
-        public static bool ListAny<T>(List<T> listConstant, Expression<Func<T,bool>> expression)
+        public static bool ListAny<T>(List<T> listConstant, Expression<Func<T, bool>> expression)
         {
             throw new NotSupportedException("Can only be used in expressions");
         }

--- a/Src/Asp.NetCore2/SqlSugar/ExpressionsToSql/Subquery/Items/SubFromTable.cs
+++ b/Src/Asp.NetCore2/SqlSugar/ExpressionsToSql/Subquery/Items/SubFromTable.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
+using System.Reflection;
 
 namespace SqlSugar
 {
@@ -51,7 +49,19 @@ namespace SqlSugar
                 this.Context.InitMappingInfo(entityType);
                 this.Context.RefreshMapping();
             }
-            var result= "FROM "+this.Context.GetTranslationTableName(name,true);
+            var result = "FROM ";
+            if (exp.Arguments.Any())
+            {
+                if (exp.Arguments[0].ToString() == "True")
+                {
+                    var tenant = entityType.GetCustomAttribute<TenantAttribute>();
+                    if (tenant != null)
+                    {
+                        result += $"{this.Context.SqlTranslationLeft}{tenant.configId}{this.Context.SqlTranslationRight}{UtilConstants.Dot}dbo{UtilConstants.Dot}";
+                    }
+                }
+            }
+            result += this.Context.GetTranslationTableName(name, true);
             if (this.Context.SubQueryIndex > 0) {
                 result += " subTableIndex"+this.Context.SubQueryIndex;
             }

--- a/Src/Asp.NetCore2/SqlSugar/ExpressionsToSql/Subquery/Items/SubFromTableWithAttr.cs
+++ b/Src/Asp.NetCore2/SqlSugar/ExpressionsToSql/Subquery/Items/SubFromTableWithAttr.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
 
 namespace SqlSugar
 {
-    public class SubFromTable : ISubOperation
+    public class SubFromTableWithAttr : ISubOperation
     {
         public bool HasWhere
         {
@@ -18,7 +15,7 @@ namespace SqlSugar
         {
             get
             {
-                return "Subqueryable";
+                return "SubqueryableWithAttr";
             }
         }
 
@@ -37,7 +34,7 @@ namespace SqlSugar
 
         public ExpressionContext Context
         {
-            get; set;
+            get;set;
         }
 
         public string GetValue(Expression expression)
@@ -53,21 +50,14 @@ namespace SqlSugar
                 this.Context.RefreshMapping();
             }
             var result = "FROM ";
-            if (exp.Arguments.Any())
+            var tenant = entityType.GetCustomAttribute<TenantAttribute>();
+            if (tenant != null)
             {
-                if (exp.Arguments[0].ToString() == "True")
-                {
-                    var tenant = entityType.GetCustomAttribute<TenantAttribute>();
-                    if (tenant != null)
-                    {
-                        result += $"{this.Context.SqlTranslationLeft}{tenant.configId}{this.Context.SqlTranslationRight}{UtilConstants.Dot}dbo{UtilConstants.Dot}";
-                    }
-                }
+                result += $"{this.Context.SqlTranslationLeft}{tenant.configId}{this.Context.SqlTranslationRight}{UtilConstants.Dot}dbo{UtilConstants.Dot}";
             }
             result += this.Context.GetTranslationTableName(name, true);
-            if (this.Context.SubQueryIndex > 0)
-            {
-                result += " subTableIndex" + this.Context.SubQueryIndex;
+            if (this.Context.SubQueryIndex > 0) {
+                result += " subTableIndex"+this.Context.SubQueryIndex;
             }
             return result;
         }

--- a/Src/Asp.NetCore2/SqlSugar/ExpressionsToSql/Subquery/SubTools.cs
+++ b/Src/Asp.NetCore2/SqlSugar/ExpressionsToSql/Subquery/SubTools.cs
@@ -24,6 +24,7 @@ namespace SqlSugar
                                                     new SubNotAny(){ Context=Context },
                                                     new SubBegin(){ Context=Context },
                                                     new SubFromTable(){ Context=Context },
+                                                    new SubFromTableWithAttr(){ Context=Context },
                                                     new SubCount(){ Context=Context },
                                                     new SubMax(){ Context=Context },
                                                     new SubMin(){ Context=Context },
@@ -48,7 +49,7 @@ namespace SqlSugar
             if (context.SubQueryIndex == 0)
                 return string.Empty;
             else
-                return "subTableIndex"+context.SubQueryIndex+".";
+                return "subTableIndex" + context.SubQueryIndex + ".";
         }
 
         public static List<ISubOperation> SubItemsConst = SubItems(null);
@@ -78,7 +79,7 @@ namespace SqlSugar
             newContext.RefreshMapping = context.RefreshMapping;
             newContext.IgnoreComumnList = context.IgnoreComumnList;
             newContext.SqlFuncServices = context.SqlFuncServices;
-            if (type == ResolveExpressType.WhereMultiple||type==ResolveExpressType.FieldMultiple) 
+            if (type == ResolveExpressType.WhereMultiple || type == ResolveExpressType.FieldMultiple)
             {
                 newContext.IsSingle = false;
             }


### PR DESCRIPTION
1.新增SqlFunc.SubqueryableWithAttr<T>方法支持跨库子查询
2.新增SqlFunc.Subqueryable<T>(bool IsCrossQueryWithAttr = false)方法支持跨库子查询