### PR TITLE
神通函数修改

### DIFF
--- a/Src/Asp.NetCore2/SqlSugar/Realization/Oscar/SqlBuilder/OscarExpressionContext.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Realization/Oscar/SqlBuilder/OscarExpressionContext.cs
@@ -119,36 +119,14 @@ namespace SqlSugar
         {
             var parameter = model.Args[0];
             var parameter2 = model.Args[1];
-            var format = "dd";
-            if (parameter2.MemberValue.ObjToString() == DateType.Year.ToString())
+            if (parameter.MemberName != null && parameter.MemberName is DateTime)
             {
-                format = "yyyy";
+                return string.Format(" datepart({0},'{1}') ", parameter2.MemberValue, parameter.MemberName);
             }
-            if (parameter2.MemberValue.ObjToString() == DateType.Month.ToString())
+            else
             {
-                format = "MM";
+                return string.Format(" datepart({0},{1}) ", parameter2.MemberValue, parameter.MemberName);
             }
-            if (parameter2.MemberValue.ObjToString() == DateType.Day.ToString())
-            {
-                format = "dd";
-            }
-            if (parameter2.MemberValue.ObjToString() == DateType.Hour.ToString())
-            {
-                format = "hh";
-            }
-            if (parameter2.MemberValue.ObjToString() == DateType.Minute.ToString())
-            {
-                format = "mm";
-            }
-            if (parameter2.MemberValue.ObjToString() == DateType.Second.ToString())
-            {
-                format = "ss";
-            }
-            if (parameter2.MemberValue.ObjToString() == DateType.Millisecond.ToString())
-            {
-                format = "ss";
-            }
-            return string.Format(" cast( to_char({1},'{0}')as integer ) ", format, parameter.MemberName);
         }
 
         public override string Contains(MethodCallExpressionModel model)
@@ -191,21 +169,7 @@ namespace SqlSugar
         {
             var parameter = model.Args[0];
             return string.Format(" CAST({0} AS timestamp)", parameter.MemberName);
-        }
-        public override string DateAddByType(MethodCallExpressionModel model)
-        {
-            var parameter = model.Args[0];
-            var parameter2 = model.Args[1];
-            var parameter3 = model.Args[2];
-            return string.Format(" ({1} +  ({2}||'{0}')::INTERVAL) ", parameter3.MemberValue, parameter.MemberName, parameter2.MemberName);
-        }
-
-        public override string DateAddDay(MethodCallExpressionModel model)
-        {
-            var parameter = model.Args[0];
-            var parameter2 = model.Args[1];
-            return string.Format(" ({0} + ({1}||'day')::INTERVAL) ", parameter.MemberName, parameter2.MemberName);
-        }
+        }     
 
         public override string ToInt32(MethodCallExpressionModel model)
         {
@@ -222,7 +186,7 @@ namespace SqlSugar
         public override string ToString(MethodCallExpressionModel model)
         {
             var parameter = model.Args[0];
-            return string.Format(" CAST({0} AS VARCHAR)", parameter.MemberName);
+            return string.Format(" CAST({0} AS VARCHAR(1024))", parameter.MemberName);
         }
 
         public override string ToGuid(MethodCallExpressionModel model)
@@ -276,6 +240,13 @@ namespace SqlSugar
         public override string EqualTrue(string fieldName)
         {
             return "( " + fieldName + "=true )";
+        }
+        public override string DateDiff(MethodCallExpressionModel model)
+        {
+            var parameter = model.Args[0];
+            var parameter2 = model.Args[1];
+            var parameter3 = model.Args[2];
+            return string.Format(" DATEDIFF('{0}',{1},{2}) ", parameter.MemberValue?.ToString().ToSqlFilter(), parameter2.MemberName, parameter3.MemberName);
         }
     }
 }


### PR DESCRIPTION
数据库版本 ： 7.0.8
修改内容：
1.DateValue 函数，神通数据库有datepart函数，与SqlServer用法一致
2. 神通有DateAdd函数，  删除重写方法DateAddByType()和DateAddDay() 使用默认的即可
3. ToString()方法。  现在的转化是“AS VARCHAR”，在神通中默认是1。所以经常会报错"字符串溢出"。又因为不支持“VARCHAR(MAX) ” 这种用法，所以我暂时写死了 1024。能够涵盖绝大部分的查询了。后续感觉可以添加一个重载。第二个参数输入长度。
4. DateDiff函数的重写：“DATEDIFF('{0}',{1},{2})”   在第一个参数上加上了单引号，  比较坑的是 如果是“day”,"month" 不写单引号也没事，但是“Hour”必须写单引号。索性就直接全加上，加上单引号之后“day”,"month"等也可以使用