### PR TITLE
Fix the redundant space when convert to pivot table with multiple row selector.

### DIFF
--- a/Src/Asp.Net/SqlSugar/Utilities/DataTableExtensions.cs
+++ b/Src/Asp.Net/SqlSugar/Utilities/DataTableExtensions.cs
@@ -62,7 +62,9 @@ namespace SqlSugar
                 foreach (DataRow row in table.Rows)
                 {
                     var json =row[firstName];
-                    var list = json.ToString().TrimStart('{').TrimEnd('}').Split(',').Select(it=>it.Split('=')).ToList();
+                    var list = json.ToString().TrimStart('{', ' ').TrimEnd('}', ' ')
+                        .Split(new[] { ", " }, StringSplitOptions.None)
+                        .Select(it => it.Split(new[] { " = " }, StringSplitOptions.None)).ToList();
                     foreach (var item in Regex.Split(firstName, UtilConstants.ReplaceKey))
                     {
                         var x = list.First(it => it.First().Trim() == item.Trim());

--- a/Src/Asp.NetCore2/SqlSugar/Utilities/DataTableExtensions.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Utilities/DataTableExtensions.cs
@@ -62,7 +62,9 @@ namespace SqlSugar
                 foreach (DataRow row in table.Rows)
                 {
                     var json =row[firstName];
-                    var list = json.ToString().TrimStart('{').TrimEnd('}').Split(',').Select(it=>it.Split('=')).ToList();
+                    var list = json.ToString().TrimStart('{', ' ').TrimEnd('}', ' ')
+                        .Split(new[] { ", " }, StringSplitOptions.None)
+                        .Select(it => it.Split(new[] { " = " }, StringSplitOptions.None)).ToList();
                     foreach (var item in Regex.Split(firstName, UtilConstants.ReplaceKey))
                     {
                         var x = list.First(it => it.First().Trim() == item.Trim());

--- a/Src/OracleUS7ASCII/SqlSugar/Utilities/DataTableExtensions.cs
+++ b/Src/OracleUS7ASCII/SqlSugar/Utilities/DataTableExtensions.cs
@@ -62,7 +62,9 @@ namespace SqlSugar
                 foreach (DataRow row in table.Rows)
                 {
                     var json =row[firstName];
-                    var list = json.ToString().TrimStart('{').TrimEnd('}').Split(',').Select(it=>it.Split('=')).ToList();
+                    var list = json.ToString().TrimStart('{', ' ').TrimEnd('}', ' ')
+                        .Split(new[] { ", " }, StringSplitOptions.None)
+                        .Select(it => it.Split(new[] { " = " }, StringSplitOptions.None)).ToList();
                     foreach (var item in Regex.Split(firstName, UtilConstants.ReplaceKey))
                     {
                         var x = list.First(it => it.First().Trim() == item.Trim());


### PR DESCRIPTION
When use ToPivotTable, if the row selector parameter has multiple fields, like

xxx.ToPivotTable(t1 => t1.A, t1 => new { t1.B, t1.C }, t1 => xxx);

, then the value of result DataTable will has a redundant space in front of it, while the last column also has a redundant space in end.