### PR TITLE
解决PGSQL10以前的自增长SERIAL和10之后的标准化写法GENERATED的兼容

### DIFF
--- a/Src/Asp.NetCore2/SqlSugar/Realization/PostgreSQL/DbMaintenance/PostgreSQLDbMaintenance.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Realization/PostgreSQL/DbMaintenance/PostgreSQLDbMaintenance.cs
@@ -30,8 +30,11 @@ namespace SqlSugar
                                 col_description(pclass.oid, pcolumn.ordinal_position) as ColumnDescription,
                                 case when pkey.colname = pcolumn.column_name
                                 then true else false end as IsPrimaryKey,
-                                case when pcolumn.column_default like 'nextval%'
-                                then true else false end as IsIdentity,
+                                CASE 
+									WHEN (current_setting('server_version_num')::INT >= 100000 AND pcolumn.is_identity = 'YES') THEN true
+									WHEN pcolumn.column_default LIKE 'nextval%' THEN true
+									ELSE false 
+								END AS IsIdentity,
                                 case when pcolumn.is_nullable = 'YES'
                                 then true else false end as IsNullable
                                  from (select * from pg_tables where upper(tablename) = upper('{0}') and schemaname='" + schema + @"') ptables inner join pg_class pclass


### PR DESCRIPTION
PGSQL 10之前一般都是用 default_value = nextval() 实现的，即SERIAL，该方法不利于数据库迁移。而10及以上的版本将自增长标准化了，即GENERATED BY DEFAULT AS IDENTITY，并成为官网的推荐写法，故作此兼容