### PR TITLE
处理在未启动事务使用MasterQueryable查询分表数据时，依旧查询从库的问题

### DIFF
--- a/Src/Asp.NetCore2/SqlSugar/Abstract/QueryableProvider/QueryableProvider.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Abstract/QueryableProvider/QueryableProvider.cs
@@ -1782,6 +1782,7 @@ namespace SqlSugar
                 unionall.QueryBuilder.Includes = this.QueryBuilder.Includes;
                 unionall.QueryBuilder.EntityType = typeof(T);
                 unionall.QueryBuilder.IsDisabledGobalFilter = this.QueryBuilder.IsDisabledGobalFilter;
+                unionall.QueryBuilder.IsDisableMasterSlaveSeparation = this.QueryBuilder.IsDisableMasterSlaveSeparation;
                 if (unionall.QueryBuilder.Includes?.Any()==true) 
                 {
                     unionall.QueryBuilder.NoCheckInclude = true;


### PR DESCRIPTION
处理在未启动事务使用MasterQueryable查询分表数据时，依旧查询从库的问题