### PR TITLE
使用BulkMergeAsync新增或更新数据时异常修改

### DIFF
--- a/Src/Asp.NetCore2/SqlSugar/Abstract/FastestProvider/FastestProvider.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Abstract/FastestProvider/FastestProvider.cs
@@ -356,14 +356,15 @@ namespace SqlSugar
 
         private async Task<int> _BulkUpdate(List<T> datas, string[] whereColumns, string[] updateColumns)
         {
+            var isAuto = this.context.CurrentConnectionConfig.IsAutoCloseConnection;
+            var old = this.context.Ado.IsDisableMasterSlaveSeparation;
             try
             {
                 Begin(datas, false);
                 Check.Exception(whereColumns == null || whereColumns.Count() == 0, "where columns count=0 or need primary key");
                 Check.Exception(updateColumns == null || updateColumns.Count() == 0, "set columns count=0");
-                var isAuto = this.context.CurrentConnectionConfig.IsAutoCloseConnection;
+                
                 this.context.CurrentConnectionConfig.IsAutoCloseConnection = false;
-                var old = this.context.Ado.IsDisableMasterSlaveSeparation;
                 this.context.Ado.IsDisableMasterSlaveSeparation = true;
                 DataTable dt = ToDdateTable(datas);
                 IFastBuilder buider = GetBuider();
@@ -377,9 +378,7 @@ namespace SqlSugar
                 {
                     this.context.DbMaintenance.DropTable(dt.TableName);
                 }
-                this.context.CurrentConnectionConfig.IsAutoCloseConnection = isAuto;
                 buider.CloseDb(); 
-                this.context.Ado.IsDisableMasterSlaveSeparation = old;
                 End(datas, false);
                 return result;
             }
@@ -387,6 +386,11 @@ namespace SqlSugar
             {
                 this.context.Close();
                 throw;
+            }
+            finally
+            {
+                this.context.CurrentConnectionConfig.IsAutoCloseConnection = isAuto;
+                this.context.Ado.IsDisableMasterSlaveSeparation = old;
             }
         }
 


### PR DESCRIPTION
使用BulkMergeAsync新增或更新数据时，由于网络波动等原因，连接被关闭删除临时表异常，导致数据库连接设置IsAutoCloseConnection恢复为原设置参数逻辑未执行。