### PR TITLE
fix(gbase): 修复时间戳差值函数间隔类型大小写问题

### DIFF
--- a/Src/Asp.NetCore2/SqlSugar.GBaseCore/GBase/SqlBuilder/GBaseExpressionContext.cs
+++ b/Src/Asp.NetCore2/SqlSugar.GBaseCore/GBase/SqlBuilder/GBaseExpressionContext.cs
@@ -203,7 +203,8 @@ namespace SqlSugar.GBase
             var parameter = model.Args[0];
             var parameter2 = model.Args[1];
             var parameter3 = model.Args[2];
-            return string.Format(" timestampdiff('{0}',{1},{2}) ", parameter.MemberValue?.ToString().ToSqlFilter(), parameter2.MemberName, parameter3.MemberName);
+            var intervalType = parameter.MemberValue?.ToString().ToSqlFilter()?.ToLower();
+            return string.Format(" timestampdiff('{0}',{1},{2}) ", intervalType, parameter2.MemberName, parameter3.MemberName);
         }
         public override string ToString(MethodCallExpressionModel model)
         {


### PR DESCRIPTION
- 将间隔类型参数转换为小写以确保GBase SQL兼容性