### PR TITLE
fix:修改在使用分页批量插入时，DmBulkCopy中BatchSize未赋值问题

### DIFF
--- a/Src/Asp.NetCore2/SqlSugar/Abstract/FastestProvider/Private.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Abstract/FastestProvider/Private.cs
@@ -40,6 +40,7 @@ namespace SqlSugar
                 case DbType.Dm:
                     var result3= new DmFastBuilder();
                     result3.DbFastestProperties.IsOffIdentity = this.IsOffIdentity;
+                    result3.DbFastestProperties.Size = this.Size;
                     return result3;
                 case DbType.ClickHouse:
                     var resultConnectorClickHouse = InstanceFactory.CreateInstance<IFastBuilder>("SqlSugar.ClickHouse.ClickHouseFastBuilder");

--- a/Src/Asp.NetCore2/SqlSugar/Abstract/FastestProvider/Private.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Abstract/FastestProvider/Private.cs
@@ -40,7 +40,7 @@ namespace SqlSugar
                 case DbType.Dm:
                     var result3= new DmFastBuilder();
                     result3.DbFastestProperties.IsOffIdentity = this.IsOffIdentity;
-                    result3.DbFastestProperties.Size = this.Size;
+                    result3.DbFastestProperties.BatchSize = this.BatchsSize;
                     return result3;
                 case DbType.ClickHouse:
                     var resultConnectorClickHouse = InstanceFactory.CreateInstance<IFastBuilder>("SqlSugar.ClickHouse.ClickHouseFastBuilder");

--- a/Src/Asp.NetCore2/SqlSugar/Abstract/FastestProvider/Setting.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Abstract/FastestProvider/Setting.cs
@@ -16,6 +16,8 @@ namespace SqlSugar
         private bool IsDataAop { get; set; }
         private bool IsOffIdentity { get; set; }
         private bool  IsIgnoreInsertError { get; set; }
+        private int BatchsSize { get; set; }
+
         public IFastest<T> SetCharacterSet(string CharacterSet) 
         {
             this.CharacterSet = CharacterSet;
@@ -54,6 +56,11 @@ namespace SqlSugar
         public IFastest<T> OffIdentity() 
         {
             this.IsOffIdentity = true;
+            return this;
+        }
+        public IFastest<T> BatchSize(int batchSize)
+        {
+            this.BatchsSize = batchSize;
             return this;
         }
         public SplitFastest<T> SplitTable() 

--- a/Src/Asp.NetCore2/SqlSugar/Entities/DbFastestProperties.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Entities/DbFastestProperties.cs
@@ -16,5 +16,6 @@ namespace SqlSugar
         public bool IsConvertDateTimeOffsetToDateTime { get; set; }
         public bool NoPage { get; set; }
         public bool IsIgnoreInsertError { get; internal set; }
+        public int Size { get; set; }
     }
 }

--- a/Src/Asp.NetCore2/SqlSugar/Entities/DbFastestProperties.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Entities/DbFastestProperties.cs
@@ -16,6 +16,6 @@ namespace SqlSugar
         public bool IsConvertDateTimeOffsetToDateTime { get; set; }
         public bool NoPage { get; set; }
         public bool IsIgnoreInsertError { get; internal set; }
-        public int Size { get; set; }
+        public int BatchSize { get; set; }
     }
 }

--- a/Src/Asp.NetCore2/SqlSugar/Interface/IFastest.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Interface/IFastest.cs
@@ -14,6 +14,7 @@ namespace SqlSugar
         IFastest<T> RemoveDataCache(string cacheKey);
         IFastest<T> AS(string tableName);
         IFastest<T> PageSize(int Size);
+        IFastest<T> BatchSize(int batchSize);
         IFastest<T> OffIdentity();
         IFastest<T> SetCharacterSet(string CharacterSet);
         IFastest<T> EnableDataAop();

--- a/Src/Asp.NetCore2/SqlSugar/Realization/Dm/SqlBuilder/DmFastBuilder.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Realization/Dm/SqlBuilder/DmFastBuilder.cs
@@ -64,6 +64,10 @@ namespace SqlSugar
         {
             DmBulkCopy bulkCopy = GetBulkCopyInstance();
             bulkCopy.DestinationTableName = dt.TableName;
+            if (DbFastestProperties?.Size > 0)
+            {
+                bulkCopy.BatchSize = DbFastestProperties.Size;
+            }
             try
             {
                 bulkCopy.WriteToServer(dt);

--- a/Src/Asp.NetCore2/SqlSugar/Realization/Dm/SqlBuilder/DmFastBuilder.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Realization/Dm/SqlBuilder/DmFastBuilder.cs
@@ -64,9 +64,9 @@ namespace SqlSugar
         {
             DmBulkCopy bulkCopy = GetBulkCopyInstance();
             bulkCopy.DestinationTableName = dt.TableName;
-            if (DbFastestProperties?.Size > 0)
+            if (DbFastestProperties?.BatchSize > 0)
             {
-                bulkCopy.BatchSize = DbFastestProperties.Size;
+                bulkCopy.BatchSize = DbFastestProperties.BatchSize;
             }
             try
             {


### PR DESCRIPTION
在使用db.Fastest<T>().PageSize(2000).BulkCopy(strTableName, dtData)时，数据集是被分成2000一批进行插入，但在底层调用DM提供的DmBulkCopy时，对象的BatchSize未赋值，一次发送的数据量始终为缺省值100。

以下来自dm程序员文档：

公共属性 
DestinationTableName：指定目标表名； 
ColumnMappings：指定源数据列与目标表列的映射集合； 
BatchSize：指定一次发送的数据行数，缺省值为100。 
