### PR TITLE
feat: 增加达梦VARCHAR类型按字符存储支持开关，解决从其他按字符存储的数据库迁移长度不够导致失败的问题

### DIFF
--- a/Src/Asp.NetCore2/SqlSugar/Entities/ConnMoreSettings.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Entities/ConnMoreSettings.cs
@@ -41,5 +41,6 @@ namespace SqlSugar
         public bool EnableJsonb { get;  set; }
         public PostgresIdentityStrategy PostgresIdentityStrategy { get; set; } = PostgresIdentityStrategy.Serial; // 兼容性处理，默认使用Serial
         internal object InnerTemp { get; set; }
+        public bool DmCodeFirstEnableCharInLength { get; set; }
     }
 }

--- a/Src/Asp.NetCore2/SqlSugar/Realization/Dm/DbMaintenance/DmDbMaintenance.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Realization/Dm/DbMaintenance/DmDbMaintenance.cs
@@ -642,7 +642,7 @@ WHERE table_name = '" + tableName + "'");
                     if (item.DbColumnName.Equals("GUID", StringComparison.CurrentCultureIgnoreCase) && item.Length == 0)
                     {
                         item.Length = 10;
-                    }
+                    } 
                 }
             }
             string sql = GetCreateTableSql(tableName, columns);
@@ -675,6 +675,14 @@ WHERE upper(t.TABLE_NAME) = upper('{tableName}')
             else {
                 return base.IsAnyTable(tableName, isCache);
             }
+        }
+        protected override string GetSize(DbColumnInfo item)
+        {
+            if (item.DataType != null && item.DataType.ToLower().Equals("varchar") && item.Length > 0 && this.Context.CurrentConnectionConfig?.MoreSettings?.DmCodeFirstEnableCharInLength == true)
+            {
+                return string.Format("({0} CHAR)", item.Length);
+            }
+            return base.GetSize(item);
         }
         #endregion
 


### PR DESCRIPTION
- 新增 `ConnMoreSettings`.`DmCodeFirstEnableCharInLength` 配置，启用开关后达梦数据库CodeFirst字段SQL调整，例：`VARCHAR(10)` 改为 `VARCHAR(10 CHAR)`