### PR TITLE
feat: 增加达梦varchar类型长度为CHAR存储方式。

### DIFF
--- a/Src/Asp.NetCore2/SqlSugar/Entities/ConnMoreSettings.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Entities/ConnMoreSettings.cs
@@ -41,5 +41,6 @@ namespace SqlSugar
         public bool EnableJsonb { get;  set; }
         public PostgresIdentityStrategy PostgresIdentityStrategy { get; set; } = PostgresIdentityStrategy.Serial; // 兼容性处理，默认使用Serial
         internal object InnerTemp { get; set; }
+        public bool DmCodeFirstEnableCharInLength { get; set; }
     }
 }

--- a/Src/Asp.NetCore2/SqlSugar/Realization/Dm/DbMaintenance/DmDbMaintenance.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Realization/Dm/DbMaintenance/DmDbMaintenance.cs
@@ -676,6 +676,14 @@ WHERE upper(t.TABLE_NAME) = upper('{tableName}')
                 return base.IsAnyTable(tableName, isCache);
             }
         }
+        protected override string GetSize(DbColumnInfo item)
+        {
+            if (item.DataType != null && item.DataType.ToLower().Equals("varchar") && item.Length > 0 && this.Context.CurrentConnectionConfig?.MoreSettings?.DmCodeFirstEnableCharInLength == true)
+            {
+                return string.Format("({0} CHAR)", item.Length);
+            }
+            return base.GetSize(item);
+        }
         #endregion
 
         #region Helper


### PR DESCRIPTION
现有代码在 EntityService 中修改 DataType 会导致生成的SQL有误：
```c#
EntityService = (s, p) =>
{
    if (s.PropertyType == typeof(string))
    {
        if (p.DataType != null
           || p.PropertyInfo.PropertyType != typeof(string)
           || (p.PropertyInfo.DeclaringType?.Namespace) == null)
        {
            return;
        }

        if (p.Length > 4000)
            throw new NotSupportedException("达梦设置4000以上长度请直接使用 ColumnDataType = StaticConfig.CodeFirst_BigString");

        var length = p.Length > 0 ? p.Length : 255;

        p.DataType = string.Format("VARCHAR({0} CHAR)", length);
    }
}
```
<img width="465" height="201" alt="acdc709c5049dfdf35b017853f653be6" src="https://github.com/user-attachments/assets/32fbeb43-82f5-4bbb-b8bc-dae3a6a5a258" />
<img width="783" height="267" alt="9e50c4796fc5a86d38ac48cae2c7d768" src="https://github.com/user-attachments/assets/c2d3a330-53e9-401b-8009-3991ee8ae7af" />



## 新增 `ConnMoreSettings.DmCodeFirstEnableCharInLength` 配置，启用后达梦数据库CodeFirst中VARCHAR类型长度按字符存储，如：VARCHAR(255 CHAR)

