### PR TITLE
修复某些情况下映射到 TimeSpan/TimeOnly 失败的问题

### DIFF
--- a/Src/Asp.NetCore2/SqlSugar/Infrastructure/ContextMethods.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Infrastructure/ContextMethods.cs
@@ -829,6 +829,10 @@ namespace SqlSugar
                         {
                             addItem = Convert.ToDateTime(addItem).ToString("yyyy-MM-dd");
                         }
+                        else if (addItem != null && (underType?.FullName is "System.TimeSpan" || underType?.FullName == "System.TimeOnly"))
+                        {
+                            addItem = Convert.ToDateTime(addItem).ToString("HH:mm:ss");
+                        }
                         else if (UtilMethods.GetUnderType(prop.PropertyType).IsEnum() && addItem is decimal)
                         {
                             if (prop.PropertyType.IsEnum() == false && addItem == null)


### PR DESCRIPTION
与 #1428 问题类似。

---

```csharp
const string connectionString = "Server=x.x.x.x:xxxx;User Id=xxxxxx;PWD=xxxx;SCHEMA=xxxx;DATABASE=xxxx";
using SqlSugarClient client = new(new ConnectionConfig
{
    DbType = DbType.Dm,
    ConnectionString = connectionString
});
var result = await client.Queryable<SomeEntity>()
    .Select(x => new
    {
        Entity = x
    })
    .Take(1)
    .ToListAsync();

[SugarTable("xxxx")]
public class SomeEntity
{
    [SugarColumn(ColumnName = "xxxx")]
    public TimeSpan? SomeTimeSpanField { get; set; }
}

```

--- 

修复前：

<img width="2314" height="462" alt="image" src="https://github.com/user-attachments/assets/cf6421e7-f981-446c-b6b5-cd3a9b19a5d3" />

<img width="3488" height="1278" alt="image" src="https://github.com/user-attachments/assets/893a5f92-3202-4220-a90a-be518ff29756" />

```log
Newtonsoft.Json.JsonSerializationException: Error converting value 2026-08-02 18:00:00 to type 'System.Nullable`1[System.TimeSpan]'. Path 'Entity.SomeTimeSpanField', line 1, position 52.
 ---> System.ArgumentException: Could not cast or convert from System.DateTime to System.TimeSpan.
   at Newtonsoft.Json.Utilities.ConvertUtils.EnsureTypeAssignable(Object value, Type initialType, Type targetType)
   at Newtonsoft.Json.Utilities.ConvertUtils.ConvertOrCast(Object initialValue, CultureInfo culture, Type targetType)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureType(JsonReader reader, Object value, CultureInfo culture, JsonContract contract, Type targetType)
   --- End of inner exception stack trace ---
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureType(JsonReader reader, Object value, CultureInfo culture, JsonContract contract, Type targetType)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.ResolvePropertyAndCreatorValues(JsonObjectContract contract, JsonProperty containerProperty, JsonReader reader, Type objectType)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObjectUsingCreatorWithParameters(JsonReader reader, JsonObjectContract contract, JsonProperty containerProperty, ObjectConstructor`1 creator, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateNewObject(JsonReader reader, JsonObjectContract objectContract, JsonProperty containerMember, JsonProperty containerProperty, String id, Boolean& createdFromNonDefaultCreator)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)
   at SqlSugar.SerializeService.DeserializeObject[T](String value) in D:\Codes\GitHub\SqlSugar\Src\Asp.NetCore2\SqlSugar\IntegrationServices\SerializeService.cs:line 56
   at SqlSugar.ContextMethods.DeserializeObject[T](String value) in D:\Codes\GitHub\SqlSugar\Src\Asp.NetCore2\SqlSugar\Infrastructure\ContextMethods.cs:line 962
   at SqlSugar.ContextMethods.<DataReaderToListAsync>d__21`1.MoveNext() in D:\Codes\GitHub\SqlSugar\Src\Asp.NetCore2\SqlSugar\Infrastructure\ContextMethods.cs:line 392
```

---

修复后：

<img width="2956" height="1252" alt="image" src="https://github.com/user-attachments/assets/0fa29992-fb3c-48ff-ae1f-adb507d18040" />

<img width="2540" height="654" alt="image" src="https://github.com/user-attachments/assets/cdfce53f-2a60-4c99-ba65-c0c99fb812a7" />
